### PR TITLE
Error in compose.yml that does not allow to run setup instruction

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ x-backend-defaults: &backend_defaults
 services:
   configurator:
     <<: *backend_defaults
-    command: configure.py
+    command: python /usr/local/bin/configure.py
     environment:
       DB_HOST: ${DB_HOST}
       DB_PORT: ${DB_PORT}
@@ -33,7 +33,7 @@ services:
     environment:
       BACKEND: backend:8000
       SOCKETIO: websocket:9000
-      FRAPPE_SITE_NAME_HEADER: ${FRAPPE_SITE_NAME_HEADER:-$$host}
+      FRAPPE_SITE_NAME_HEADER: ${FRAPPE_SITE_NAME_HEADER:-$host}
       UPSTREAM_REAL_IP_ADDRESS: ${UPSTREAM_REAL_IP_ADDRESS:-127.0.0.1}
       UPSTREAM_REAL_IP_HEADER: ${UPSTREAM_REAL_IP_HEADER:-X-Forwarded-For}
       UPSTREAM_REAL_IP_RECURSIVE: ${UPSTREAM_REAL_IP_RECURSIVE:-off}


### PR DESCRIPTION
Following the instruction in https://github.com/vrslev/frappe_docker/blob/beautify/docs/setup-options.md

### Setup ERPNext using containerized MariaDB and Redis with Letsencrypt certificates.

```sh
# Generate YAML
docker-compose -f compose.yaml \
  -f overrides/compose.erpnext.yaml \
  -f overrides/compose.mariadb.yaml \
  -f overrides/compose.redis.yaml \
  -f overrides/compose.https.yaml \
  config > ~/gitops/docker-compose.yml

# Start containers
docker-compose --project <project-name> -f ~/gitops/docker-compose.yml up -d
```
I come across 2 errors:
1. container `project_configurator_1` do not have file configure.py
2. `FRAPPE_SITE_NAME_HEADER: ${FRAPPE_SITE_NAME_HEADER:-$$host}` transform into `FRAPPE_SITE_NAME_HEADER: $$$$host` .
using `FRAPPE_SITE_NAME_HEADER: ${FRAPPE_SITE_NAME_HEADER:-$$host}` allow the statement to be `FRAPPE_SITE_NAME_HEADER: $$host`  after config overide
